### PR TITLE
Cleanup and minor fixes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -27,11 +27,12 @@
 # General code TODOs
 - Decide whether we want to do stuff like fd closing whenever a stdlib function fails.
 - Do we want to handle when the header is malformed, because it *doesn't* end with \r\n\r\n?
+- Rename ClientData to Client?
 
 # PDF questions
 - "You can’t execve another web server." - So should we add explicit logic that throws an exception if one does try to do it? Or are they saying the program is allowed to segfault if the evaluator tries to do it?
 - "Your server must never block and the client can be bounced properly if necessary." - What does bouncing of clients precisely mean? Isn't poll() technically going to block the program, or is this maybe not called blocking?
-- "poll() (or equivalent) must check read and write at the same time." - Is this saying that modifying the "events" field of a pollfd struct on the fly to switch between POLLIN and POLLOUT is forbidden?
+- "poll() (or equivalent) must check read and write at the same time." - Is this saying that modifying the "events" field of a pollfd struct on the fly to switch between POLLIN and POLLOUT is forbidden? Or is it just saying that a single poll() call should be used, rather than one for POLLIN, and one for POLLOUT?
 - "Because you have to use non-blocking file descriptors, it is possible to use read/recv or write/send functions with no poll() (or equivalent), and your server wouldn’t be blocking. But it would consume more system resources." - What would exactly happen to the system resources?
 - "A request to your server should never hang forever." - How do we test this?
 - "Your server must have default error pages if none are provided." - What do they mean by "if none are provided"? Are they saying that some pages *have* to have different looking error pages?
@@ -71,3 +72,5 @@ http://f1r3s6.codam.nl:8080/
 - Test read and write sizes 1, 2, 3, 4, 5
 - "Search for all read/recv/write/send and check if the returned value is correctly checked (checking only -1 or 0 values is not enough, both should be checked)." - Eval sheet
 - Make sure we're not using the errno global directly: "If errno is checked after read/recv/write/send, the grade is 0 and the evaluation process ends now."
+- Decide whether all of ClientData's copied member variables in the copy constructor and copy assignment operator make sense to be copied, or whether they should be initialized to the starting state
+- Double-check that the C++ classes' initializer lists aren't forgetting to initialize a member variable

--- a/experiments/append_empty.cpp
+++ b/experiments/append_empty.cpp
@@ -1,0 +1,17 @@
+#include <cassert>
+#include <string>
+
+// c++ append_empty.cpp -Wall -Wextra -Werror -Wpedantic -Wfatal-errors -g -fsanitize=address,undefined && ./a.out
+int main(void)
+{
+	std::string body("a");
+	char received[] = "b";
+
+	body.append(received, received + 1);
+	assert(body == "ab");
+
+	body.append(received + 1, received + 1);
+	assert(body == "ab");
+
+	return EXIT_SUCCESS;
+}

--- a/experiments/cgi.cpp
+++ b/experiments/cgi.cpp
@@ -103,7 +103,7 @@ int main(int argc, char *argv[], char *envp[])
 				return EXIT_FAILURE;
 			}
 
-			// Send 'received' to Python script stdin
+			// Write 'received' to Python script stdin
 			fprintf(stderr, "Parent is going to write '%s' to Python\n", received);
 			if (write(tube_client_to_cgi[PIPE_WRITE_INDEX], received, MAX_RECEIVED_LEN) == -1)
 			{

--- a/experiments/client.cpp
+++ b/experiments/client.cpp
@@ -69,7 +69,7 @@ int main(int argc, char *argv[])
 	}
 
 	// Set up socket struct
-	struct sockaddr_in socket;
+	sockaddr_in socket;
 	bzero(&socket, sizeof(socket));
 	socket.sin_family = AF_INET;
 	// Convert host (our) byte order to the network byte order as short (uint16_t)
@@ -82,7 +82,7 @@ int main(int argc, char *argv[])
 		die("inet_pton with IP '%s'", ip_str);
 	}
 
-	if (connect(socket_fd, (struct sockaddr *)&socket, sizeof(socket)) < 0)
+	if (connect(socket_fd, (sockaddr *)&socket, sizeof(socket)) < 0)
 	{
 		die("connect");
 	}

--- a/experiments/getaddrinfo.cpp
+++ b/experiments/getaddrinfo.cpp
@@ -15,8 +15,8 @@ int main(int argc, char *argv[])
 
 	const char *hostname = argv[1];
 
-	struct addrinfo hint;
-	struct addrinfo *result;
+	addrinfo hint;
+	addrinfo *result;
 
 	bzero(&hint, sizeof(hint));
 
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
 		return EXIT_FAILURE;
 	}
 
-	struct addrinfo *tmp = result;
+	addrinfo *tmp = result;
 	while (tmp)
 	{
 		printf("Entry:\n");
@@ -58,12 +58,12 @@ int main(int argc, char *argv[])
 		if (tmp->ai_family == AF_INET)
 		{
 			// IPv4
-			address = &((struct sockaddr_in *)tmp->ai_addr)->sin_addr;
+			address = &((sockaddr_in *)tmp->ai_addr)->sin_addr;
 		}
 		else
 		{
 			// IPv6
-			address = &((struct sockaddr_in6 *)tmp->ai_addr)->sin6_addr;
+			address = &((sockaddr_in6 *)tmp->ai_addr)->sin6_addr;
 		}
 
 		// Network representation to printable string

--- a/experiments/getprotobyname.cpp
+++ b/experiments/getprotobyname.cpp
@@ -31,7 +31,7 @@ int main(void)
 			printf("\n");
 		}
 
-		struct protoent *servptr = getprotobyname(protocol[i]);
+		protoent *servptr = getprotobyname(protocol[i]);
 
 		if (servptr == NULL)
 		{

--- a/experiments/print.py
+++ b/experiments/print.py
@@ -1,10 +1,12 @@
-import sys
+import json, os, sys
 
 
 def main():
     print(f"argv: {sys.argv}")
 
     print(f"stdin: {sys.stdin.readlines()}")
+
+    print(f"env: {json.dumps(dict(os.environ), sort_keys=True, indent=4)}")
 
     exit(2)
 

--- a/experiments/server.cpp
+++ b/experiments/server.cpp
@@ -13,7 +13,7 @@
 // TODO: Move some/all of these defines to a config file
 #define SERVER_PORT 18000
 
-#define MAX_CONNECTION_QUEUE_LENGTH 1
+#define MAX_CONNECTION_QUEUE_LEN 1
 
 #define MAX_RECEIVED_LEN 300
 
@@ -63,19 +63,19 @@ int main(void)
 	int option = 1; // "the parameter should be non-zero to enable a boolean option"
 	setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, &option, sizeof(option));
 
-	struct sockaddr_in servaddr;
+	sockaddr_in servaddr;
 	bzero(&servaddr, sizeof(servaddr));
 	servaddr.sin_family = AF_INET;
 	servaddr.sin_addr.s_addr = htonl(INADDR_ANY);
 	servaddr.sin_port = htons(SERVER_PORT);
 
-	if ((bind(server_fd, (struct sockaddr *)&servaddr, sizeof(servaddr))) < 0)
+	if ((bind(server_fd, (sockaddr *)&servaddr, sizeof(servaddr))) < 0)
 	{
 		perror("bind");
 		exit(EXIT_FAILURE);
 	}
 
-	if ((listen(server_fd, MAX_CONNECTION_QUEUE_LENGTH)) < 0)
+	if ((listen(server_fd, MAX_CONNECTION_QUEUE_LEN)) < 0)
 	{
 		perror("listen");
 		exit(EXIT_FAILURE);
@@ -84,7 +84,7 @@ int main(void)
 	nfds_t nfds = 2;
 
 	// TODO: Don't use the forbidden fn calloc()
-	struct pollfd *poll_fds = (struct pollfd *)calloc(nfds, sizeof(struct pollfd));
+	pollfd *poll_fds = (pollfd *)calloc(nfds, sizeof(pollfd));
 	if (poll_fds == NULL)
 	{
 		perror("calloc");

--- a/experiments/stat.cpp
+++ b/experiments/stat.cpp
@@ -10,7 +10,7 @@
 int main(void)
 {
 	const char *path = "stat.cpp";
-	struct stat buf;
+	stat buf;
 
 	if (stat(path, &buf))
 	{

--- a/src/ClientData.hpp
+++ b/src/ClientData.hpp
@@ -19,10 +19,11 @@ class ClientData
 {
 public:
 	ClientData(void);
-	ClientData(int client_fd);
 	ClientData(ClientData const &src);
 	virtual ~ClientData(void);
 	ClientData &operator=(ClientData const &src);
+
+	ClientData(int client_fd);
 
 	bool readSocket(void);
 
@@ -37,7 +38,7 @@ public:
 	std::string protocol;
 	std::unordered_map<std::string, std::string> header_map;
 	std::string body;
-	size_t respond_index;
+	size_t response_index;
 
 private:
 	bool parseHeaders(void);

--- a/src/ClientData.hpp
+++ b/src/ClientData.hpp
@@ -15,6 +15,28 @@ size_t for sent characters (i)
 // Ignore chunked request doody for now (will be my part probably)
 */
 
+namespace ReadState
+{
+	enum ReadState
+	{
+		HEADER,
+		BODY,
+		READING_FROM_CGI,
+		DONE
+	};
+}
+
+namespace WriteState
+{
+	enum WriteState
+	{
+		NOT_WRITING,
+		WRITING_TO_CGI,
+		WRITING_TO_CLIENT,
+		DONE
+	};
+}
+
 class ClientData
 {
 public:
@@ -27,12 +49,25 @@ public:
 
 	bool readSocket(void);
 
-	enum State
-	{
-		HEADER = 0,
-		BODY,
-		DONE
-	} read_state;
+	// enum ReadState
+	// {
+	// 	HEADER,
+	// 	BODY,
+	// 	READING_FROM_CGI,
+	// 	READING_DONE
+	// } read_state;
+
+	// enum WriteState
+	// {
+	// 	NOT_WRITING,
+	// 	WRITING_TO_CGI,
+	// 	WRITING_TO_CLIENT,
+	// 	WRITING_DONE
+	// } write_state;
+
+	ReadState::ReadState read_state;
+	WriteState::WriteState write_state;
+
 	std::string request_method;
 	std::string path;
 	std::string protocol;

--- a/src/ClientData.hpp
+++ b/src/ClientData.hpp
@@ -49,22 +49,6 @@ public:
 
 	bool readSocket(void);
 
-	// enum ReadState
-	// {
-	// 	HEADER,
-	// 	BODY,
-	// 	READING_FROM_CGI,
-	// 	READING_DONE
-	// } read_state;
-
-	// enum WriteState
-	// {
-	// 	NOT_WRITING,
-	// 	WRITING_TO_CGI,
-	// 	WRITING_TO_CLIENT,
-	// 	WRITING_DONE
-	// } write_state;
-
 	ReadState::ReadState read_state;
 	WriteState::WriteState write_state;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -161,7 +161,7 @@ int main(void)
 						int client_fd = pfds[j].fd;
 						ClientData &client = client_data[client_fd];
 
-						bool previous_read_state = client.read_state;
+						ReadState::ReadState previous_read_state = client.read_state;
 
 						if (!client.readSocket())
 						{
@@ -170,14 +170,14 @@ int main(void)
 						}
 
 						// If we've just started reading this client's body
-						if (previous_read_state != ClientData::BODY && client.read_state == ClientData::BODY)
+						if (previous_read_state != ReadState::BODY && client.read_state == ReadState::BODY)
 						{
 							// std::cerr << "foo" << std::endl;
 
 							// Turn on the POLLOUT bit
 							pfds[j].events |= POLLOUT;
 						}
-						else if (client.read_state == ClientData::DONE)
+						else if (client.read_state == ReadState::DONE)
 						{
 							// Turn off the POLLIN bit
 							// Not strictly necessary, since POLLIN can't be raised after read() returned 0 anyways


### PR DESCRIPTION
- Let print.py print env
- Strings were uninitialized
- Remove redundant struct keywords
- Rename poll_fds to pfds
- Add swap-remove explanation
- Add ReadState and WriteState namespaces (to prevent `DONE` enum name collision error)